### PR TITLE
Feat: Format multiple JSONs, one per line

### DIFF
--- a/addon/globalPlugins/nvda_json/__init__.py
+++ b/addon/globalPlugins/nvda_json/__init__.py
@@ -15,6 +15,20 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         formatted_json = self.__format_json(parsed_json)
         ui.browseableMessage(formatted_json, 'Formatted JSON', False)
 
+    def script_format_multiple_jsons_from_selected_text_or_clipboard(self, gesture):
+        text = self.__get_text()
+        lines = filter(lambda line: line != '', map(lambda line: line.strip(), text.splitlines()))
+        parsed_jsons_list = []
+        for line in lines:
+            try:
+                parsed_jsons_list.append(json.loads(line))
+            except json.decoder.JSONDecodeError as error:
+                continue
+        if parsed_jsons_list == []:
+            ui.message('No JSONs to display')
+        formatted_json = self.__format_json(parsed_jsons_list)
+        ui.browseableMessage(formatted_json, 'Formatted JSONs', False)
+
     def __get_text(self):
         return self.__get_selected_text() or api.getClipData()
 
@@ -39,4 +53,5 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
     __gestures = {
         'kb:nvda+j': 'format_json_from_selected_text_or_clipboard',
+        'kb:nvda+shift+j': 'format_multiple_jsons_from_selected_text_or_clipboard',
     }

--- a/readme.md
+++ b/readme.md
@@ -5,3 +5,15 @@ JSON utilities for NVDA.
 ## Usage
 
 * NVDA+j: If there is text selected, takes the selected JSON text and shows it formatted in a NVDA browseable dialog. If no text is selected, it shows the formatted Json text dialog taking the Json data from the clipboard.
+* NVDA+shift+j: formats multiple JSONS in the same text
+
+### How multi JSONS feature works
+
+There are situations that we have multiple JSONs, one per line (log lines for example):
+
+```
+{"datetime": "2022-03-10 21:04:05", "level": "info", "message": "user logged in"}
+{"datetime": "2022-03-10 21:04:08", "level": "error", "message": "Database is down"}
+```
+
+When you press "NVDA+shift+j" this plugin takes each line, formats and displays all elements as a list.

--- a/readme.md
+++ b/readme.md
@@ -17,3 +17,20 @@ There are situations that we have multiple JSONs, one per line (log lines for ex
 ```
 
 When you press "NVDA+shift+j" this plugin takes each line, formats and displays all elements as a list.
+
+The formatted text will be displaied as follows:
+
+```
+[
+    {
+        "datetime": "2022-03-10 21:04:05",
+        "level": "info",
+        "message": "user logged in"
+    },
+    {
+        "datetime": "2022-03-10 21:04:08",
+        "level": "error",
+        "message": "Database is down"
+    }
+]
+```


### PR DESCRIPTION
A feature to formate a text that contains multiple JSONs, one per line.

Given this text:

```
{"datetime": "2022-03-10 21:04:05", "level": "info", "message": "user logged in"}
{"datetime": "2022-03-10 21:04:08", "level": "error", "message": "Database is down"}
```

Pressing "NVDA+shift+j" this plugin will try to parse line by line, appending the valid results to an internal list. This list will be formatted and displaied.

The result will be:

```
[
    {
        "datetime": "2022-03-10 21:04:05",
        "level": "info",
        "message": "user logged in"
    },
    {
        "datetime": "2022-03-10 21:04:08",
        "level": "error",
        "message": "Database is down"
    }
]
```


Original idea from @marlon-sousa