### PR TITLE
feat: Added button to copy output to clipboard

### DIFF
--- a/addon/globalPlugins/nvda_json/json_dialog.py
+++ b/addon/globalPlugins/nvda_json/json_dialog.py
@@ -1,4 +1,5 @@
 import json
+import api
 import ui
 import wx
 
@@ -22,6 +23,9 @@ class JsonDialog(wx.Dialog):
         self.output = wx.TextCtrl(self, style=wx.TE_MULTILINE | wx.TE_READONLY)
         jsonSizer.Add(outputLabel)
         jsonSizer.Add(self.output, 1, wx.EXPAND | wx.ALL, 5)
+        copyOutputButton = wx.Button(self, label="Copy output to clipboard")
+        copyOutputButton.Bind(wx.EVT_BUTTON, self.on_copy_output_click)
+        jsonSizer.Add(copyOutputButton, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
         mainSizer.Add(jsonSizer, 1, wx.EXPAND | wx.ALL, 5)
         self.SetSizer(mainSizer)
         self.Bind(wx.EVT_CHAR_HOOK, self.onKey)
@@ -34,6 +38,13 @@ class JsonDialog(wx.Dialog):
 
     def onClose(self, evt):
         self.Destroy()
+
+    def on_copy_output_click(self, event):
+        copied = api.copyToClip(self.output.GetValue())
+        if copied:
+            ui.message('Copied')
+        else:
+            ui.message('Error when copying')
 
     def parse_text(self, text, multi):
         if multi:

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ The formatted text will be displaied as follows:
   * [x] Original JSON using Python's json module
   * [ ] json5
 * [ ] Interactive JSON through a UI
+  * [x] Button to copy output to clipboard
   * [ ] JSON Filtering / transformation
     * [ ] With JSON Pointer ("/timestamp") (https://github.com/stefankoegl/python-json-pointer)
     * [ ] With JQ (".timestamp") (https://jqlang.github.io/jq/, https://github.com/mwilliamson/jq.py)


### PR DESCRIPTION
This pull request introduces a new feature to the `json_dialog.py` file, allowing users to copy JSON output to the clipboard. Additionally, it updates the `readme.md` to reflect this new feature.

New feature implementation:

* [`addon/globalPlugins/nvda_json/json_dialog.py`](diffhunk://#diff-505110d85e861cb76dbf3318e82ef806c66ce38470ac4cd89ad8d8ce87038f3eR26-R28): Added a "Copy output to clipboard" button to the UI and implemented the `on_copy_output_click` method to handle the button click event. This method uses the `api.copyToClip` function to copy the output and provides feedback to the user via the `ui.message` function. [[1]](diffhunk://#diff-505110d85e861cb76dbf3318e82ef806c66ce38470ac4cd89ad8d8ce87038f3eR26-R28) [[2]](diffhunk://#diff-505110d85e861cb76dbf3318e82ef806c66ce38470ac4cd89ad8d8ce87038f3eR42-R48)

Documentation update:

* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R49): Updated to include the new feature of copying JSON output to the clipboard.