### PR TITLE
feat: Adds JSONPath support

### DIFF
--- a/addon/globalPlugins/nvda_json/__init__.py
+++ b/addon/globalPlugins/nvda_json/__init__.py
@@ -1,3 +1,7 @@
+import os
+import sys
+sys.path.append(os.path.dirname(__file__)+'../../modules')
+
 import api
 import globalPluginHandler
 import gui

--- a/addon/globalPlugins/nvda_json/json_dialog.py
+++ b/addon/globalPlugins/nvda_json/json_dialog.py
@@ -1,6 +1,10 @@
 import json
+
 import api
 import ui
+
+import jsonpath_ng
+import jsonpath_ng.ext
 import wx
 
 class JsonDialog(wx.Dialog):
@@ -19,6 +23,10 @@ class JsonDialog(wx.Dialog):
         self.originalText = wx.TextCtrl(self, style=wx.TE_MULTILINE | wx.TE_READONLY)
         jsonSizer.Add(originalTextLabel)
         jsonSizer.Add(self.originalText, 1, wx.EXPAND | wx.ALL, 5)
+        pathExpressionLabel = wx.StaticText(self, label="Path Expression")
+        self.pathExpression = wx.TextCtrl(self, style=wx.TE_LEFT|wx.TE_PROCESS_ENTER )
+        jsonSizer.Add(pathExpressionLabel)
+        jsonSizer.Add(self.pathExpression, 0, wx.EXPAND | wx.ALL, 5)
         outputLabel = wx.StaticText(self, label="Output")
         self.output = wx.TextCtrl(self, style=wx.TE_MULTILINE | wx.TE_READONLY)
         jsonSizer.Add(outputLabel)
@@ -29,6 +37,8 @@ class JsonDialog(wx.Dialog):
         mainSizer.Add(jsonSizer, 1, wx.EXPAND | wx.ALL, 5)
         self.SetSizer(mainSizer)
         self.Bind(wx.EVT_CHAR_HOOK, self.onKey)
+        self.pathExpression.Bind(wx.EVT_TEXT_ENTER, self.on_path_expression_enter)
+        self.pathExpression.SetWindowStyleFlag(wx.TE_PROCESS_ENTER)
 
     def onKey(self, event):
         if event.GetKeyCode() == wx.WXK_ESCAPE:
@@ -70,6 +80,22 @@ class JsonDialog(wx.Dialog):
         if parsed_jsons_list == []:
             ui.message('No JSONs to display')
         return self.__format_json(parsed_jsons_list)
+
+    def on_path_expression_enter(self, event):
+        expression = self.pathExpression.GetValue().strip()
+        if expression == '$':
+            self.output.SetValue(self.parse_text(self.text, self.multi))
+            return
+        try:
+            jsonpath_expr = jsonpath_ng.ext.parse(expression)
+            json_data = json.loads(self.parse_text(self.text, self.multi))
+            matches = [match.value for match in jsonpath_expr.find(json_data)]
+            if matches:
+                self.output.SetValue(self.__format_json(matches))
+            else:
+                ui.message('No matches found')
+        except (json.decoder.JSONDecodeError, jsonpath_ng.exceptions.JsonPathParserError) as e:
+            ui.message(f'Error: {str(e)}')
 
     def __format_json(self, parsed_json):
         return json.dumps(

--- a/addon/globalPlugins/nvda_json/json_dialog.py
+++ b/addon/globalPlugins/nvda_json/json_dialog.py
@@ -83,14 +83,12 @@ class JsonDialog(wx.Dialog):
 
     def on_path_expression_enter(self, event):
         expression = self.pathExpression.GetValue().strip()
-        if expression == '$':
-            self.output.SetValue(self.parse_text(self.text, self.multi))
-            return
         try:
             jsonpath_expr = jsonpath_ng.ext.parse(expression)
             json_data = json.loads(self.parse_text(self.text, self.multi))
             matches = [match.value for match in jsonpath_expr.find(json_data)]
             if matches:
+                matches = matches[0] if len(matches) == 1 else matches
                 self.output.SetValue(self.__format_json(matches))
             else:
                 ui.message('No matches found')

--- a/addon/globalPlugins/nvda_json/json_dialog.py
+++ b/addon/globalPlugins/nvda_json/json_dialog.py
@@ -94,8 +94,8 @@ class JsonDialog(wx.Dialog):
                 self.output.SetValue(self.__format_json(matches))
             else:
                 ui.message('No matches found')
-        except (json.decoder.JSONDecodeError, jsonpath_ng.exceptions.JsonPathParserError) as e:
-            ui.message(f'Error: {str(e)}')
+        except (jsonpath_ng.exceptions.JsonPathLexerError, jsonpath_ng.exceptions.JsonPathParserError) as e:
+            ui.message(f'JSONPath Expression Error: {str(e)}')
 
     def __format_json(self, parsed_json):
         return json.dumps(

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,6 @@ The formatted text will be displaied as follows:
 * [ ] Interactive JSON through a UI
   * [x] Button to copy output to clipboard
   * [ ] JSON Filtering / transformation
-    * [ ] With JSONPath (https://goessner.net/articles/JsonPath/, https://github.com/h2non/jsonpath-ng)
+    * [x] With JSONPath (https://goessner.net/articles/JsonPath/, https://github.com/h2non/jsonpath-ng)
     * [ ] With JQ (https://jqlang.github.io/jq/, https://github.com/mwilliamson/jq.py)
     * [ ] Save filters / transformations to avoid typing (program and description)

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,49 @@ The formatted text will be displaied as follows:
 ]
 ```
 
+### JSONPath
+
+Between the "original text" and the "output" is a "path expression" field.
+This field accepts a JSONPath expression.
+JSONPath is a syntax that allows filtering JSON items. You can write the
+expression and press enter to see the filtered result in the "output" field.
+
+You can learn JSONPath in the [documentation](https://goessner.net/articles/JsonPath/)
+
+Let's discover this feature by example.
+
+Given these JSON lines:
+
+```
+{"name": "Josiel", "gender": "male", "birth_date": "1995-07-03"}
+{"name": "Luzia", "gender": "female", "birth_date": "1945-03-19"}
+{"name": "PH", "gender": "male", "birth_date": "2004-03-18"}
+```
+
+#### Get all people names
+
+```
+$..name
+```
+
+#### Get only male people
+
+```
+$[?(@.gender == 'male')]
+```
+
+#### Get only young people (born before year 2000)
+
+```
+$[?(@.birth_date > '2000-01-01')]
+```
+
+#### Get the original JSON
+
+```
+$
+```
+
 ## Features (implemented and future)
 
 * [x] Parsing JSON from clipboard


### PR DESCRIPTION
This pull request adds support for JSONPath using the [jsonpath-ng module](https://github.com/h2non/jsonpath-ng?tab=readme-ov-file).
JSONPath is like XPath for JSON. 
jsonpath-ng supports standard and more extensions.