### PR TITLE
fix: Correctly show accents in output

### DIFF
--- a/addon/globalPlugins/nvda_json/json_dialog.py
+++ b/addon/globalPlugins/nvda_json/json_dialog.py
@@ -108,6 +108,7 @@ class JsonDialog(wx.Dialog):
     def __format_json(self, parsed_json):
         return json.dumps(
             parsed_json,
+            ensure_ascii = False,
             indent=4,
             sort_keys=True
         )

--- a/buildVars.py
+++ b/buildVars.py
@@ -26,7 +26,7 @@ addon_info = {
         "addon_description": _("""JSON utilities for NVDA
 """),
         # version
-        "addon_version": "1.0.1",
+        "addon_version": "1.0.2",
         # Author(s)
         "addon_author": "Josiel Santos <josiel.lkp@gmail.com>",
         # URL for the add-on documentation support

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,15 @@
 
 ### Bug Fixes
 
+* Correctly show accents in output ([f3fc3ea](https://github.com/JosielSantos/nvda-json/commit/f3fc3ea40f769af863bc1c03786167170b0d392f))
+
+
+
+#  (2024-11-08)
+
+
+### Bug Fixes
+
 * Error when importing dependent modules ([481a730](https://github.com/JosielSantos/nvda-json/commit/481a7307e178a0dd64ac16123878dfc4c9d7db24))
 
 


### PR DESCRIPTION
Currently, the accents are presented as unescaped unicode:

```
{
    "terra": "\u00c1gua"
}
```

This PR fixes this be disabling the "ensure_ascii" flag in json.dumps function.

Now, the correct output will be presented:

```
{
    "terra": "Água"
}
```