### PR TITLE
feat: String transformation using JSONPointer

### DIFF
--- a/addon/globalPlugins/nvda_json/abstract.py
+++ b/addon/globalPlugins/nvda_json/abstract.py
@@ -6,10 +6,9 @@ import ui
 import wx
 
 class Dialog(wx.Dialog):
-    def __init__(self, parent, text, multi):
-        super(Dialog, self).__init__(parent, title="NVDA JSON")
+    def __init__(self, parent, text, title = 'NVDA JSON'):
+        super(Dialog, self).__init__(parent, title = title)
         self.text = text
-        self.multi = multi
         self.create_ui()
 
     def onKey(self, event):

--- a/addon/globalPlugins/nvda_json/json_query_dialog.py
+++ b/addon/globalPlugins/nvda_json/json_query_dialog.py
@@ -11,7 +11,8 @@ from .abstract import Dialog as AbstractDialog
 
 class JsonQueryDialog(AbstractDialog):
     def __init__(self, parent, text, multi):
-        super(JsonQueryDialog, self).__init__(parent, text, multi)
+        super(JsonQueryDialog, self).__init__(parent, text, title = 'JSON Query')
+        self.multi = multi
         self.originalText.SetValue(text)
         self.set_output(self.parse_text(self.text, self.multi))
 
@@ -40,7 +41,6 @@ class JsonQueryDialog(AbstractDialog):
         self.SetSizer(mainSizer)
         self.Bind(wx.EVT_CHAR_HOOK, self.onKey)
         self.pathExpression.Bind(wx.EVT_TEXT_ENTER, self.on_path_expression_enter)
-        self.pathExpression.SetWindowStyleFlag(wx.TE_PROCESS_ENTER)
 
     def on_copy_output_click(self, event):
         copied = api.copyToClip(self.output.GetValue())

--- a/addon/globalPlugins/nvda_json/json_template_dialog.py
+++ b/addon/globalPlugins/nvda_json/json_template_dialog.py
@@ -1,0 +1,80 @@
+import json
+
+import api
+import ui
+
+import jsonpointer
+import wx
+
+from .abstract import Dialog as AbstractDialog
+
+class JsonTemplateDialog(AbstractDialog):
+    def __init__(self, parent, text):
+        super(JsonTemplateDialog, self).__init__(parent, text, title = 'JSON template')
+        self.originalText.SetValue(text)
+
+    def set_output(self, output):
+        self.output.SetValue(output if output is not None else '')
+
+    def create_ui(self):
+        mainSizer = wx.BoxSizer(wx.VERTICAL)
+        jsonSizer = wx.BoxSizer(wx.VERTICAL)
+        originalTextLabel = wx.StaticText(self, label = "Original text")
+        self.originalText = wx.TextCtrl(self, style=wx.TE_MULTILINE | wx.TE_READONLY)
+        jsonSizer.Add(originalTextLabel)
+        jsonSizer.Add(self.originalText, 1, wx.EXPAND | wx.ALL, 5)
+        templateLabel = wx.StaticText(self, label="Template")
+        self.template = wx.TextCtrl(self, style=wx.TE_LEFT|wx.TE_PROCESS_ENTER )
+        jsonSizer.Add(templateLabel)
+        jsonSizer.Add(self.template, 0, wx.EXPAND | wx.ALL, 5)
+        outputLabel = wx.StaticText(self, label="Output")
+        self.output = wx.TextCtrl(self, style=wx.TE_MULTILINE | wx.TE_READONLY)
+        jsonSizer.Add(outputLabel)
+        jsonSizer.Add(self.output, 1, wx.EXPAND | wx.ALL, 5)
+        copyOutputButton = wx.Button(self, label="Copy output to clipboard")
+        copyOutputButton.Bind(wx.EVT_BUTTON, self.on_copy_output_click)
+        jsonSizer.Add(copyOutputButton, 0, wx.ALIGN_RIGHT | wx.ALL, 5)
+        mainSizer.Add(jsonSizer, 1, wx.EXPAND | wx.ALL, 5)
+        self.SetSizer(mainSizer)
+        self.Bind(wx.EVT_CHAR_HOOK, self.onKey)
+        self.template.Bind(wx.EVT_TEXT_ENTER, self.on_template_enter)
+
+    def on_copy_output_click(self, event):
+        copied = api.copyToClip(self.output.GetValue())
+        if copied:
+            ui.message('Copied')
+        else:
+            ui.message('Error when copying')
+
+    def on_template_enter(self, event):
+        template = self.template.GetValue().strip()
+        json_data = json.loads(self.parse_text(self.text, False))
+        self.set_output(self.parse_template(json_data, template))
+
+    def parse_template(self, data, template):
+        result = ''
+        escape = False
+        i = 0
+        while i < len(template):
+            if template[i] == "\\":
+                escape = True
+                i += 1
+                continue
+            if template[i] == '{' and not escape:
+                end_index = template.find('}', i)
+                if end_index != -1:
+                    pointer = template[i + 1:end_index]
+                    try:
+                        value = jsonpointer.resolve_pointer(data, pointer)
+                        result += str(value)
+                    except jsonpointer.JsonPointerException:
+                        result += '{' + pointer + '}'
+                    i = end_index + 1
+                    continue
+            if escape:
+                result += template[i]
+                escape = False
+            else:
+                result += template[i]
+            i += 1
+        return result

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,9 @@
 #  (2024-11-09)
 
-#  (2024-11-09)
-
 ### Features
 
-* Add addon submenu on 'NVDA>tools' menu ([3d6f2c5](https://github.com/JosielSantos/nvda-json/commit/3d6f2c54c4ebfe478752b87e65e92f7eb71e5d48))
+* Add addon submenu on 'NVDA>tools' menu ([#16](https://github.com/JosielSantos/nvda-json/issues/16)) ([ed97a7f](https://github.com/JosielSantos/nvda-json/commit/ed97a7f6850ab78054e8132c605ee84ca8043584))
+* String transformations using JSONPointer syntax ([515826b](https://github.com/JosielSantos/nvda-json/commit/515826b3a266449a1cfd8951b43673f4fb4e7ce3))
 
 #  (2024-11-08)
 

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,34 @@ $[?(@.birth_date > '2000-01-01')]
 $
 ```
 
+### String transformation with JSONPointer (NVDA+ctrl+j)
+
+Original idea from @thgcode in [this issue](https://github.com/JosielSantos/nvda-json/issues/6)
+
+Given this JSON:
+
+```
+{
+    "name": "Josiel",
+    "family": {
+        "mother": {"name": "Maria"}
+    },
+    "programming_languages": ["Java", "PHP"]
+}
+```
+
+With this functionality you can create strings using placeholders with JSONPointer syntax:
+
+```
+My name is {/name}, My mother is {/family/mother/name} and my favorite programming language is {/programming_languages/1}
+```
+
+Output:
+
+```
+My name is Josiel, My mother is Maria and my favorite programming language is PHP
+```
+
 ## Features (implemented and future)
 
 * [x] Parsing JSON from clipboard
@@ -94,3 +122,4 @@ $
     * [x] With JSONPath (https://goessner.net/articles/JsonPath/, https://github.com/h2non/jsonpath-ng)
     * [ ] With JQ (https://jqlang.github.io/jq/, https://github.com/mwilliamson/jq.py)
     * [ ] Save filters / transformations to avoid typing (program and description)
+    * [x] String transformation using JSONPointer (https://datatracker.ietf.org/doc/html/rfc6901, https://github.com/stefankoegl/python-json-pointer?tab=readme-ov-file)


### PR DESCRIPTION
Adds string transformation using JSONPointer syntax.

Given this JSON:

```
{
    "name": "Josiel",
    "family": {
        "mother": {"name": "Maria"}
    },
    "programming_languages": ["Java", "PHP"]
}
```

With this functionality you can create strings using placeholders with JSONPointer syntax:

```
My name is {/name}, My mother is {/family/mother/name} and my favorite programming language is {/programming_languages/1}
```

Output:

```
My name is Josiel, My mother is Maria and my favorite programming language is PHP
```