### PR TITLE
feat: Adds auto complete with saved queries

### DIFF
--- a/addon/globalPlugins/nvda_json/gui_components/__init__.py
+++ b/addon/globalPlugins/nvda_json/gui_components/__init__.py
@@ -1,0 +1,1 @@
+from .auto_complete_text_ctrl import *

--- a/addon/globalPlugins/nvda_json/gui_components/auto_complete_text_ctrl.py
+++ b/addon/globalPlugins/nvda_json/gui_components/auto_complete_text_ctrl.py
@@ -1,0 +1,95 @@
+import wx
+
+EVT_AUTOCOMPLETE_ENTER_TYPE = wx.NewEventType()
+EVT_AUTOCOMPLETE_ENTER = wx.PyEventBinder(EVT_AUTOCOMPLETE_ENTER_TYPE, 1)
+
+class AutoCompleteEnterEvent(wx.PyCommandEvent):
+    def __init__(self, event_type, event_id, value):
+        super().__init__(event_type, event_id)
+        self._value = value
+
+    def GetValue(self):
+        return self._value
+
+
+class AutoCompleteTextCtrl(wx.TextCtrl):
+    def __init__(self, parent, choices, *args, **kwargs):
+        super(AutoCompleteTextCtrl, self).__init__(parent, *args, **kwargs)
+        self.choices = choices
+        self.listbox = None
+        self.Bind(wx.EVT_TEXT, self.on_text_change)
+        self.Bind(wx.EVT_KEY_DOWN, self.on_key_down)
+
+    def on_text_change(self, event):
+        text = self.GetValue()
+        if text:
+            matches = [choice for choice in self.choices if text.lower() in choice.lower()]
+            if matches:
+                self.show_listbox(matches)
+            else:
+                self.hide_listbox()
+        else:
+            self.hide_listbox()
+        event.Skip()
+
+    def on_key_down(self, event):
+        if self.listbox and self.listbox.IsShown():
+            if event.GetKeyCode() == wx.WXK_DOWN:
+                self.listbox.SetFocus()
+                self.listbox.SetSelection(0)
+            elif event.GetKeyCode() == wx.WXK_UP:
+                self.listbox.SetFocus()
+                self.listbox.SetSelection(self.listbox.GetCount() - 1)
+        event.Skip()
+
+    def show_listbox(self, choices):
+        if not self.listbox:
+            self.listbox = wx.ListBox(self.GetParent(), choices=choices)
+            self.listbox.Bind(wx.EVT_CHAR_HOOK, self.on_listbox_key_down)
+            self.GetParent().json_sizer.Add(self.listbox, 0, wx.EXPAND)
+        else:
+            self.listbox.Set(choices)
+        self.listbox.SetSize((self.GetSize().width, 150))
+        self.listbox.SetPosition(self.ClientToScreen((0, self.GetSize().height)))
+        self.listbox.Show()
+
+    def hide_listbox(self):
+        if self.listbox:
+            self.listbox.Hide()
+
+    def on_listbox_key_down(self, event):
+        if event.GetKeyCode() == wx.WXK_RETURN:
+            if self.listbox.GetSelection() != wx.NOT_FOUND:
+                value = self.listbox.GetStringSelection()
+                self.SetValue(value)
+                self.SetInsertionPointEnd()
+                autocomplete_event = AutoCompleteEnterEvent(EVT_AUTOCOMPLETE_ENTER_TYPE, self.GetId(), value)
+                wx.PostEvent(self.GetEventHandler(), autocomplete_event)
+            self.hide_listbox()
+        elif event.GetKeyCode() == wx.WXK_ESCAPE:
+            self.SetFocus()
+            self.hide_listbox()
+        elif event.GetKeyCode() == wx.WXK_BACK:
+            self.delete_last_char()
+            self.SetFocus()
+        elif event.GetKeyCode() == wx.WXK_UP:
+            if self.listbox.GetSelection() == 0:
+                self.SetFocus()
+                self.listbox.SetSelection(wx.NOT_FOUND)
+        elif event.GetKeyCode() == wx.WXK_DOWN:
+            if self.listbox.GetSelection() == self.listbox.GetCount() - 1:
+                self.SetFocus()
+                self.listbox.SetSelection(wx.NOT_FOUND)
+        event.Skip()
+
+    def delete_last_char(self):
+        text = self.GetValue()
+        if text:
+            self.SetValue(text[:-1])
+            self.SetInsertionPointEnd()
+            text_event = wx.CommandEvent(wx.wxEVT_TEXT, self.GetId())
+            text_event.SetString(self.GetValue())
+            wx.PostEvent(self.GetEventHandler(), text_event)
+
+    def set_choices(self, choices):
+        self.choices = choices

--- a/addon/globalPlugins/nvda_json/json_query_dialog.py
+++ b/addon/globalPlugins/nvda_json/json_query_dialog.py
@@ -25,9 +25,9 @@ class JsonQueryDialog(JsonManipulatorDialog):
     }
 
     def __init__(self, parent, text, multi):
-        super(JsonQueryDialog, self).__init__(parent, text, title = 'JSON Query')
         self.query_engine = JsonQueryDialog.query_engines[config.conf['json']['query_engine']]
         self.expression_type = self.query_engine['type']
+        super(JsonQueryDialog, self).__init__(parent, text, title = 'JSON Query')
         self.label_manipulation_expression.SetLabel(self.query_engine['edit_label'])
         self.multi = multi
         self.set_output(self.parse_text(self.text, self.multi))

--- a/addon/globalPlugins/nvda_json/json_template_dialog.py
+++ b/addon/globalPlugins/nvda_json/json_template_dialog.py
@@ -9,8 +9,8 @@ from .abstract import JsonManipulatorDialog
 
 class JsonTemplateDialog(JsonManipulatorDialog):
     def __init__(self, parent, text):
-        super(JsonTemplateDialog, self).__init__(parent, text, title = 'JSON template')
         self.expression_type = 'jsonpointer-template'
+        super(JsonTemplateDialog, self).__init__(parent, text, title = 'JSON template')
         self.label_manipulation_expression.SetLabel('Template')
         self.original_text.SetValue(text)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+#  (2024-11-27)
+
+### Features
+
+* Adds auto complete with saved expressions ([d73ac60](https://github.com/JosielSantos/nvda-json/commit/d73ac6061ed06c28cb797f26dc96d0eb772902ad))
+* Delete saved query from autocomplete list by pressing the delete key ([76cfe9e](https://github.com/JosielSantos/nvda-json/commit/76cfe9e38279d201c6b1921ec685f4262b612d9c))
+
 #  (2024-11-23)
 
 ### Features

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,20 @@ Output:
 My name is Josiel, My mother is Maria and my favorite programming language is PHP
 ```
 
+### Using autocomplete
+
+On expression edit field:
+
+* Press ctrl+enter to execute / save a query
+* Type part of expression
+* Use up / down arrow to access the suggestions list
+
+In the suggestions list:
+
+* Press enter to fill the edit field with the complete expression and execute it
+* Press backspace to delete the last character in the edit field and move focus back to it
+* Press delete to remove the saved expression
+
 ## Features (implemented and future)
 
 * [x] Parsing JSON from clipboard
@@ -135,8 +149,9 @@ My name is Josiel, My mother is Maria and my favorite programming language is PH
   * [ ] json5
 * [ ] Interactive JSON through a UI
   * [x] Button to copy output to clipboard
-  * [ ] JSON Filtering / transformation
+  * [x ] JSON Filtering / transformation
     * [x] With JSONPath (https://goessner.net/articles/JsonPath/, https://github.com/h2non/jsonpath-ng)
     * [x] With JQ (https://jqlang.github.io/jq/, https://github.com/mwilliamson/jq.py)
-    * [ ] Save filters / transformations to avoid typing (program and description)
+    * [x] Save filters / transformations to avoid typing (program and description)
+    * [x] Autocomplete with saved queries
     * [x] String transformation using JSONPointer (https://datatracker.ietf.org/doc/html/rfc6901, https://github.com/stefankoegl/python-json-pointer?tab=readme-ov-file)


### PR DESCRIPTION
Added autocomplete from saved queries.

* When starting to type a expression, a listbox will be filled
* In the edit field, when pressing down key, the focus move to first item
* In the edit field, when pressing up key, the focus will move to the last item
* In the listbox, when pressing backspace, the last char of the edit will be deleted and the focus will back to the edit field
* When pressing enter key, the selected expression will be executed
* When press delete, The expression will be deleted from saved queries

Now when pressing enter in the edit, the expression will be executed and the focus will go to the output readonly field.